### PR TITLE
Hide Why ivory exempt field for portrait miniatures

### DIFF
--- a/customisations/customisations.js
+++ b/customisations/customisations.js
@@ -467,7 +467,7 @@ this.exemptionTypeOnChange = executionContext => {
     case ExemptionTypeLookup.MINIATURE:
       formContext.getControl(DataVerseFieldName.WHY_IVORY_INTEGRAL).setVisible(false);
       formContext.getControl(DataVerseFieldName.WHY_AGE_EXEMPT).setVisible(true);
-      formContext.getControl(DataVerseFieldName.WHY_IVORY_EXEMPT).setVisible(true);
+      formContext.getControl(DataVerseFieldName.WHY_IVORY_EXEMPT).setVisible(false);
 
       formContext.getAttribute(DataVerseFieldName.WHY_IVORY_INTEGRAL).setValue(null);
       break;


### PR DESCRIPTION
IVORY-667: Hide why ivory exempt field for portrait miniatures

The 'why ivory exempt' field was not being hidden for portrait miniatures, even though it is N/A for that exemption type.